### PR TITLE
Added John Nanotrasen design doc. All Hail John Nanotrasen

### DIFF
--- a/src/design/antagonists/John Nanotrasen.md
+++ b/src/design/antagonists/John Nanotrasen.md
@@ -1,0 +1,65 @@
+# John NanoTrasen Antagonist
+
+Your title should convey the basic jist of your proposed changes. It should be short because the text will be linked in the sidebar.
+
+| Designers | Implemented | GitHub Links |
+|---|---|---|
+| mxghast (gastlytidings, GhastIsBack) | :x: No | TBD |
+
+## Overview
+
+John NanoTrasen would be an admin-spawn-only antagonist role that exists primarily to add humor and roleplay to rounds by allowing the mascot and possibly CEO...? of Nanotrasen him/them/her/itself to visit the station and entertain themselves with it's denizens. Wrestle a few bears, obliterate an uppity crew member with a single punch, and go home after a couple beers.  
+
+## Background
+
+John NanoTrasen has been consistently referenced as a joke both in character and out of character in numerous servers. While it would be best to make whether or not they are the actual CEO of NanoTrasen ambigious, to avoid "oops, the clown fucked up the entire setting with a bottle of space lube and an emagged recycling machine" type moments, this meme seems like the perfect opportunity to add a reference to an infamous TF2 gamemode that originated from the community of TF2: Vs Saxton Hale.
+
+There was also a discussion about superheroes at one point on the Discord, no I'm not linking it because it is only barely relevant, but having John NanoTrasen (and maybe the barely whispered of John Syndicate) be the only actually powerful or relevant characters of that kind of role seems extremely funny to me. 
+
+However, the VS Saxton Hale context makes it more viable and interesting as it's own distinct gamerule and/or concept. 
+
+## Features to be added
+
+### John NanoTrasen
+
+John NanoTrasen would be a manual admin-spawned antagonist role, likely assigned to themselves or other trusted players such as other admins, as well as their/her/him/it's own rare greenshift-like gamemode. 
+
+John NanoTrasen them/her/him/itself would have a randomized appearance, species, and gender. As John NanoTrasen is the shining beacon of what it is to be a member of NanoTrasen, they/she/he/it would have a scrambled appearance to hide the true identity of John NanoTrasen behind the DNA-scrambler mask and represent ALL of NanoTrasen's employees.
+
+Mechanically, John Nanotrasen would be unique as a humanoid player controlled creature that has extremely high base statistics. Similar to the aforementioned Saxton Hale, John NanoTrasen would be absurdly strong and fast, with punches that blow limbs off of people and quickly melt through structures, and the ability to withstand even point blank explosions with no armor and without dying. John Nanotrasen would not regenerate and attrition fighting WOULD be possible if somehow it came to that point. 
+
+### John NanoTrasen's Loadout
+
+John NanoTrasen would become equipped with some extraordinarily valuable equipment, but none of it would be offensive or defensive in nature thanks to John NanoTrasen's tendency to rely on it/their/her/his nanite enhanced body. Instead, it would all be primarily utility.
+
+John NanoTrasen is of equipped with the following unique items:
+- Limited-edition NanoTrasen branded green tanktop, with a small hidden storage pocket. 
+- Unique Durathread shorts, which are necessary so John Nanotrasen's absurd strength doesn't remove their/her/his/it's decency. 
+- The NT Nanobelt, the peak of NanoTrasen engineering in a modified champion belt. No one can take it off someone or put it on someone other than John NanoTrasen him/her/them/itself. The NT Nanobelt allows it's wearer to fly infinitely in space as if they were wearing a jetpack, though it does not use any fuel. Normal people get torn apart by the forces inside the belt when used by them, as it is not designed for regular human(oid) physiology.
+- The John NanoTrasen Medal of Approval, to be given to exceptional members of the crew who help John Nanotrasen find bears to fight or something. 
+
+Give a description of what game mechanics you would like to add or change. This should be a general overview, with enough details on critical design points that someone can directly implement the feature from this design document. Exact numbers for game balance however are not necessary, as these can be adjusted later either during development or after it has been implemented, but mention *what* will have to be balanced and what needs to be considered when doing so.
+
+## Game Design Rationale
+
+Adding a humorous and rare semi-antagonist like John Nanotrasen would inject even more silliness into the game and in a way that prevents the binary good/evil conflicts with traditional antagonist roles. Everyone is both an enemy of John Nanotrasen and a friend of John Nanotrasen until they are proven worthy of being one or the other. 
+
+The role would create a humorous remix on the roleplay tension that having a Nanotrasen Representative or the future possible Magistrate brings to command roles, by having a higher up that is not just higher ranking than command but capable of obliterating them at any moment, and also has no investment in the station whatsoever. 
+
+## Roundflow & Player interaction
+
+The role would primarily exist as a pre-packaged "admeme" that admins could throw into the server to liven up a boring or one dimensional round. A greenshift could be spiced up by forcing the crew to entertain the almighty John Nanotrasen, or a already losing major antagonist round could have the antagonists face John Nanotrasen's wrath as they/he/she/it demands the station hold the antagonists to face judgement. 
+
+John Nanotrasen could also work as a 'regulator' role for numerous things during events or happenings, such as being an absurdly powerful enforcer of rules at a sports event or game. 
+
+Generally speaking, the purpose of John Nanotrasen regardless of the round John Nanotrasen is chosen to appear in would be to seek adventure and glory, alcohol and other concerning substances, and entertaining fights if possible, while bringing the full weight of fury down on whoever makes John Nanotrasen's time on station even slightly more boring (John Nanotrasen would just beat the shit out of them, not round remove). The exact actions of John Nanotrasen would be up to the player assigned to the role. 
+
+## Administrative & Server Rule Impact (if applicable)
+
+This should hopefully lessen the workload on admins by giving them a fun and easily replayable pre-packaged event to spring on players, allowing admins more space to breathe during 'boring' or uneventful rounds.
+
+The role should NOT be available by any means besides it being chosen by an admin as an assigned role. The likelihood for random players to grief with it would be too high, however, the humor potential for a trusted player or admin would also be very high. 
+
+# Technical Considerations
+
+Hopefully, this suggestion should be possible to implement with no or limited C# code. The prototypes necessary to make a new humanoid mob creature already exist, and John Nanotrasen's equipment would be primarily cosmetic and spritework oriented work. 

--- a/src/design/antagonists/John Nanotrasen.md.backup
+++ b/src/design/antagonists/John Nanotrasen.md.backup
@@ -1,0 +1,65 @@
+# John NanoTrasen Antagonist
+
+Your title should convey the basic jist of your proposed changes. It should be short because the text will be linked in the sidebar.
+
+| Designers | Implemented | GitHub Links |
+|---|---|---|
+| mxghast (gastlytidings, GhastIsBack) | :x: No | TBD |
+
+## Overview
+
+John NanoTrasen would be an admin-spawn-only antagonist role that exists primarily to add humor and roleplay to rounds by allowing the mascot and possibly CEO...? of Nanotrasen him/them/her/itself to visit the station and entertain themselves with it's denizens. Wrestle a few bears, obliterate an uppity crew member with a single punch, and go home after a couple beers.  
+
+## Background
+
+John NanoTrasen has been consistently referenced as a joke both in character and out of character in numerous servers. While it would be best to make whether or not they are the actual CEO of NanoTrasen ambigious, to avoid "oops, the clown fucked up the entire setting with a bottle of space lube and an emagged recycling machine" type moments, this meme seems like the perfect opportunity to add a reference to an infamous TF2 gamemode that originated from the community of TF2: Vs Saxton Hale.
+
+There was also a discussion about superheroes at one point on the Discord, no I'm not linking it because it is only barely relevant, but having John NanoTrasen (and maybe the barely whispered of John Syndicate) be the only actually powerful or relevant characters of that kind of role seems extremely funny to me. 
+
+However, the VS Saxton Hale context makes it more viable and interesting as it's own distinct gamerule and/or concept. 
+
+## Features to be added
+
+### John NanoTrasen
+
+John NanoTrasen would be a manual admin-spawned antagonist role, likely assigned to themselves or other trusted players such as other admins, as well as their/her/him/it's own rare greenshift-like gamemode. 
+
+John NanoTrasen them/her/him/itself would have a randomized appearance, species, and gender. As John NanoTrasen is the shining beacon of what it is to be a member of NanoTrasen, they/she/he/it would have a scrambled appearance to hide the true identity of John NanoTrasen behind the DNA-scrambler mask and represent ALL of NanoTrasen's employees.
+
+Mechanically, John Nanotrasen would be unique as a humanoid player controlled creature that has extremely high base statistics. Similar to the aforementioned Saxton Hale, John NanoTrasen would be absurdly strong and fast, with punches that blow limbs off of people and quickly melt through structures, and the ability to withstand even point blank explosions with no armor and without dying. John Nanotrasen would not regenerate and attrition fighting WOULD be possible if somehow it came to that point. 
+
+### John NanoTrasen's Loadout
+
+John NanoTrasen would become equipped with some extraordinarily valuable equipment, but none of it would be offensive or defensive in nature thanks to John NanoTrasen's tendency to rely on it/their/her/his nanite enhanced body. Instead, it would all be primarily utility.
+
+John NanoTrasen is of equipped with the following unique items:
+- Limited-edition NanoTrasen branded green tanktop, with a small hidden storage pocket. 
+- Unique Durathread shorts, which are necessary so John Nanotrasen's absurd strength doesn't remove their/her/his/it's decency. 
+- The NT Nanobelt, the peak of NanoTrasen engineering in a modified champion belt. No one can take it off someone or put it on someone other than John NanoTrasen him/her/them/itself. The NT Nanobelt allows it's wearer to fly infinitely in space as if they were wearing a jetpack, though it does not use any fuel. Normal people get torn apart by the forces inside the belt when used by them, as it is not designed for regular human(oid) physiology.
+- The John NanoTrasen Medal of Approval, to be given to exceptional members of the crew who help John Nanotrasen find bears to fight or something. 
+
+Give a description of what game mechanics you would like to add or change. This should be a general overview, with enough details on critical design points that someone can directly implement the feature from this design document. Exact numbers for game balance however are not necessary, as these can be adjusted later either during development or after it has been implemented, but mention *what* will have to be balanced and what needs to be considered when doing so.
+
+## Game Design Rationale
+
+Adding a humorous and rare semi-antagonist like John Nanotrasen would inject even more silliness into the game and in a way that prevents the binary good/evil conflicts with traditional antagonist roles. Everyone is both an enemy of John Nanotrasen and a friend of John Nanotrasen until they are proven worthy of being one or the other. 
+
+The role would create a humorous remix on the roleplay tension that having a Nanotrasen Representative or the future possible Magistrate brings to command roles, by having a higher up that is not just higher ranking than command but capable of obliterating them at any moment, and also has no investment in the station whatsoever. 
+
+## Roundflow & Player interaction
+
+The role would primarily exist as a pre-packaged "admeme" that admins could throw into the server to liven up a boring or one dimensional round. A greenshift could be spiced up by forcing the crew to entertain the almighty John Nanotrasen, or a already losing major antagonist round could have the antagonists face John Nanotrasen's wrath as they/he/she/it demands the station hold the antagonists to face judgement. 
+
+John Nanotrasen could also work as a 'regulator' role for numerous things during events or happenings, such as being an absurdly powerful enforcer of rules at a sports event or game. 
+
+Generally speaking, the purpose of John Nanotrasen regardless of the round John Nanotrasen is chosen to appear in would be to seek adventure and glory, alcohol and other concerning substances, and entertaining fights if possible, while bringing the full weight of fury down on whoever makes John Nanotrasen's time on station even slightly more boring (John Nanotrasen would just beat the shit out of them, not round remove). The exact actions of John Nanotrasen would be up to the player assigned to the role. 
+
+## Administrative & Server Rule Impact (if applicable)
+
+This should hopefully lessen the workload on admins by giving them a fun and easily replayable pre-packaged event to spring on players, allowing admins more space to breathe during 'boring' or uneventful rounds.
+
+The role should NOT be available by any means besides it being chosen by an admin as an assigned role. The likelihood for random players to grief with it would be too high, however, the humor potential for a trusted player or admin would also be very high. 
+
+# Technical Considerations
+
+Hopefully, this suggestion should be possible to implement with no or limited C# code. The prototypes necessary to make a new humanoid mob creature already exist, and 


### PR DESCRIPTION
John Nanotrasen would be a rare admin-spawn-only solo 'antagonist' that may more may not be the CEO of Nanotrasen, with their purpose on station being to seek glory, adventure, and fun. The role would only be manually assigned, and would be an extremely powerful character who creates unease and tension in the crew by being someone you do not deny lightly, while also likely making very silly requests. 