### PR TITLE
Holy Damage Redesign

### DIFF
--- a/src/design-proposals/holy-damage.md
+++ b/src/design-proposals/holy-damage.md
@@ -20,7 +20,7 @@ The damage can also be healed via the chaplain's bible and through 'Aqua Vitae',
 
 
 All magical entities should be able to deal and receive arcane damage. The chaplain, cosmic cultists, blood cultists, heretics and wizards all should have options that deal damage and ways to heal it.
-- Chaplains will deal the arcane damage primarily via their non-support nullrods (as the support nullrods would remain focused on support rather than damage). They would be able to use the bible to quickly heal said damage on anyone afflicted by it via their bible (so after deconverting someone they can heal them from the damage).
+- Chaplains will deal the arcane damage primarily via their non-support nullrods (as the support nullrods would remain focused on support rather than damage). They would be able to use the bible to quickly heal said damage on anyone afflicted by it (so after deconverting someone they can heal them from the damage).
 - Blood cults should be able to deal arcane damage via their knives and abilities, and their pylon should be able to heal it relatively quickly.
 - Cosmic cultists should deal arcane damage via their weapons and abilities, and heal it via producing Aqua Vitae and through their ability to heal when near the monument.
 - A heretic would never normally lose to a chaplain in a scenario where they go against eachother solo, but the heretic would still be able to deal arcane damage via their blades and abilities. Their summons should also be able to deal arcane when attacking.

--- a/src/design-proposals/holy-damage.md
+++ b/src/design-proposals/holy-damage.md
@@ -28,7 +28,7 @@ All magical entities should be able to deal and receive arcane damage. The chapl
 ## Holy Item Crafting
 Both science, the chaplain and sec should be able to craft items that deal and increase the resistance to arcane damage. Allowing them to interact between eachother will also increase the possible RP between them.
 - The chaplain should be able to create items and light armor that protects against arcane damage. These can come in many flavours, from charms and sigils to tinfoil hats. They should also be able to bless items to deal slight holy damage for a limited time, so increasing the possible roleplay interactions between them and sec. On top of that, the holy water the chaplain makes should be able to deal arcane damage against magical threats splashed with it.
-- Security should be able to make basic weapons that deal holy damage (but not as much as chaps), such as silver knives and stakes. These would not be as good as nomral bullets against unarmored magical threats, but against things like heretic armor, cosmic armor and blood cult armor it would be preferrable, and otherwise very useless agains non-magical threats.
+- Security should be able to make basic weapons that deal holy damage (but not as much as chaps), such as silver knives and stakes. These would not be as good as normal weapons against unarmored magical threats, but against things like heretic armor, cosmic armor and blood cult armor it would be preferrable, and otherwise very useless agains non-magical threats.
 - Science should be able to research items to help both the chaplain and security against magical threats. Such items could include reality anchors (items that passively heal arcane damage), but shouldn't have as many options as the chaplain.
 
 ## Changes

--- a/src/design-proposals/holy-damage.md
+++ b/src/design-proposals/holy-damage.md
@@ -20,10 +20,10 @@ The damage can also be healed via the chaplain's bible and through 'Aqua Vitae',
 
 
 All magical entities should be able to deal and receive arcane damage. The chaplain, cosmic cultists, blood cultists, heretics and wizards all should have options that deal damage and ways to heal it.
-> Chaplains will deal the holy damage primarily via their non-support nullrods (as the support nullrods would remain focused on support rather than damage). They would be able to use the bible to quickly heal said damage on anyone afflicted by it via their bible (so after deconverting someone they can heal them from the damage).
-> Blood cults should be able to deal arcane damage via their knives and abilities, and their pylon should be able to heal it relatively quickly.
-> Cosmic cultists should deal arcane damage via their weapons and abilities, and heal it via producing Aqua Vitae and through their ability to heal when near the monument.
-> A heretic would never normally lose to a chaplain in a scenario where they go against eachother solo, but the heretic would still be able to deal arcane damage via their blades and abilities. Their summons should also be able to deal arcane when attacking.
+- Chaplains will deal the holy damage primarily via their non-support nullrods (as the support nullrods would remain focused on support rather than damage). They would be able to use the bible to quickly heal said damage on anyone afflicted by it via their bible (so after deconverting someone they can heal them from the damage).
+- Blood cults should be able to deal arcane damage via their knives and abilities, and their pylon should be able to heal it relatively quickly.
+- Cosmic cultists should deal arcane damage via their weapons and abilities, and heal it via producing Aqua Vitae and through their ability to heal when near the monument.
+- A heretic would never normally lose to a chaplain in a scenario where they go against eachother solo, but the heretic would still be able to deal arcane damage via their blades and abilities. Their summons should also be able to deal arcane when attacking.
 
 ## Changes
 

--- a/src/design-proposals/holy-damage.md
+++ b/src/design-proposals/holy-damage.md
@@ -15,20 +15,26 @@ Holy damage should have it's name changed to arcane damage, which is how it will
 
 ## Arcane Damage
 
-Holy damage is a damage that ignores armor, dealing the damage directly to the soul of the afflicted. This damage cannot be healed via topicals and such, but it should heal by itself relatively fast (maybe 0.5 or 0.75 per second) even on dead mobs.
-The damage can also be healed via the chaplain's bible and through 'Aqua Vitae', a chemical made with wine, salt and gold that is able to quickly heal holy damage.
+Arcane damage is a damage that ignores armor, dealing the damage directly to the soul of the afflicted. This damage cannot be healed via topicals and such, but it should heal by itself relatively fast (maybe 0.5 or 0.75 per second) even on dead mobs.
+The damage can also be healed via the chaplain's bible and through 'Aqua Vitae', a chemical made with wine, salt and gold that is able to quickly heal arcane damage.
 
 
 All magical entities should be able to deal and receive arcane damage. The chaplain, cosmic cultists, blood cultists, heretics and wizards all should have options that deal damage and ways to heal it.
-- Chaplains will deal the holy damage primarily via their non-support nullrods (as the support nullrods would remain focused on support rather than damage). They would be able to use the bible to quickly heal said damage on anyone afflicted by it via their bible (so after deconverting someone they can heal them from the damage).
+- Chaplains will deal the arcane damage primarily via their non-support nullrods (as the support nullrods would remain focused on support rather than damage). They would be able to use the bible to quickly heal said damage on anyone afflicted by it via their bible (so after deconverting someone they can heal them from the damage).
 - Blood cults should be able to deal arcane damage via their knives and abilities, and their pylon should be able to heal it relatively quickly.
 - Cosmic cultists should deal arcane damage via their weapons and abilities, and heal it via producing Aqua Vitae and through their ability to heal when near the monument.
 - A heretic would never normally lose to a chaplain in a scenario where they go against eachother solo, but the heretic would still be able to deal arcane damage via their blades and abilities. Their summons should also be able to deal arcane when attacking.
 
+## Holy Item Crafting
+Both science, the chaplain and sec should be able to craft items that deal and increase the resistance to arcane damage. Allowing them to interact between eachother will also increase the possible RP between them.
+- The chaplain should be able to create items and light armor that protects against arcane damage. These can come in many flavours, from charms and sigils to tinfoil hats. They should also be able to bless items to deal slight holy damage for a limited time, so increasing the possible roleplay interactions between them and sec. On top of that, the holy water the chaplain makes should be able to deal arcane damage against magical threats splashed with it.
+- Security should be able to make basic weapons that deal holy damage (but not as much as chaps), such as silver knives and stakes. These would not be as good as nomral bullets against unarmored magical threats, but against things like heretic armor, cosmic armor and blood cult armor it would be preferrable, and otherwise very useless agains non-magical threats.
+- Science should be able to research items to help both the chaplain and security against magical threats. Such items could include reality anchors (items that passively heal arcane damage), but shouldn't have as many options as the chaplain.
+
 ## Changes
 
 Changing the arcane damage will require the modifiction of the default healing rates of every mob as to make them regenerate arcane damage passively (which may be done via changing both basemob and baseflyingmob) and to create a component that allows the damage container of the mob to receive arcane damage.
-It will also require modification of all the chaplain, cultist and heretic weapons and abilities to deal holy damage, alongside changing the damage and abilities of some mobs (such as the entropic colossus and the heretic summons).
+It will also require modification of all the chaplain, cultist and heretic weapons and abilities to deal arcane damage, alongside changing the damage and abilities of some mobs (such as the entropic colossus and the heretic summons).
 
 ## Final Considerations
-With these changes, most of which are relatively simple (though tedious), we can decrease the powercreep of chaplain nullrods, increase the interaction of the chaplain with the magic antagonists theyre intended to interact with and encourage less validhunting.
+With these changes, we can decrease the powercreep of chaplain nullrods, increase the interaction of the chaplain with the magic antagonists theyre intended to interact with and encourage less validhunting.

--- a/src/design-proposals/holy-damage.md
+++ b/src/design-proposals/holy-damage.md
@@ -1,0 +1,34 @@
+# Holy Damage Rework
+
+| Designers | Requires code | GitHub Links |
+|---|---|---|
+| SigmaTheDragon (Discord: Sigma Draconis) | :x: Yes | N/A |
+
+
+## Overview
+Holy damage is a damage type that is currently nearly useless. The only entity that even takes holy damage is the revenant, and that is only due to how it's health works.
+This document aims to rework the holy damage into an entirely new 'arcane' damage and solve the issue where the chaplain is effective against most antags.
+
+
+### Damage name change
+Holy damage should have it's name changed to arcane damage, which is how it will be mentioned as in this document from now on. This is in large part to not make implications on what/if religions are 'holy' or not.
+
+## Arcane Damage
+
+Holy damage is a damage that ignores armor, dealing the damage directly to the soul of the afflicted. This damage cannot be healed via topicals and such, but it should heal by itself relatively fast (maybe 0.5 or 0.75 per second) even on dead mobs.
+The damage can also be healed via the chaplain's bible and through 'Aqua Vitae', a chemical made with wine, salt and gold that is able to quickly heal holy damage.
+
+
+All magical entities should be able to deal and receive arcane damage. The chaplain, cosmic cultists, blood cultists, heretics and wizards all should have options that deal damage and ways to heal it.
+> Chaplains will deal the holy damage primarily via their non-support nullrods (as the support nullrods would remain focused on support rather than damage). They would be able to use the bible to quickly heal said damage on anyone afflicted by it via their bible (so after deconverting someone they can heal them from the damage).
+> Blood cults should be able to deal arcane damage via their knives and abilities, and their pylon should be able to heal it relatively quickly.
+> Cosmic cultists should deal arcane damage via their weapons and abilities, and heal it via producing Aqua Vitae and through their ability to heal when near the monument.
+> A heretic would never normally lose to a chaplain in a scenario where they go against eachother solo, but the heretic would still be able to deal arcane damage via their blades and abilities. Their summons should also be able to deal arcane when attacking.
+
+## Changes
+
+Changing the arcane damage will require the modifiction of the default healing rates of every mob as to make them regenerate arcane damage passively (which may be done via changing both basemob and baseflyingmob) and to create a component that allows the damage container of the mob to receive arcane damage.
+It will also require modification of all the chaplain, cultist and heretic weapons and abilities to deal holy damage, alongside changing the damage and abilities of some mobs (such as the entropic colossus and the heretic summons).
+
+## Final Considerations
+With these changes, most of which are relatively simple (though tedious), we can decrease the powercreep of chaplain nullrods, increase the interaction of the chaplain with the magic antagonists theyre intended to interact with and encourage less validhunting.


### PR DESCRIPTION
Holy damage is the most useless damage type of them all. Please, i'd rather deal ion than holy damage ;-;

Will also serve to rebalance the chap powercreep so that they deal more with the antags they are supposed to deal with.