### PR TITLE
Subroles & Quantum siblings subrole proposal

### DIFF
--- a/src/design-proposals/subroles/quantum-siblings.md
+++ b/src/design-proposals/subroles/quantum-siblings.md
@@ -1,0 +1,22 @@
+# Quantum Siblings
+
+| Designers | Implemented | GitHub Links |
+|---|---|---|
+| BombasterDS | :x: No | TBD |
+
+## Overview
+Quantum siblings is round-start subrole that bound two random players of same species on station with quantum connection. These two players don't get information on start is their quantum sibling. Siblings do not get any abilities, equipment or objectives. Any pair of humanoid players on station can become quantum siblings. This does not affect players outside the station (nukies).
+
+Sibling A can visually distinguish sibling B from other players (icon or aura around them). Any effect on body of sibling A will be shared with sibling B. When sibling A get damage, sibling B get same damage without way to block this damage. This also applied to healing - when sibling A get healed, sibling B heals same damage. They also share their food, chemicals and status effects - when sibling A is stunned, sibling B is stunned too. And when sibling A lost his arm - sibling B with lose it too. At the end, they also share death and gibbing.
+
+Quantum siblings are designed to lead funny interactions in the round dependings on roles of siblings. Imagine situations where captain and traitor become siblings, so captain must protect or lock their sibling just to not die.
+
+Of course, if sibling is a traitor - they can't roll objective to kill their sibling.
+
+## Goals
+- Quantum siblings do not have obvious goal. Players must deal with the situation they find themselves in.
+
+## Possible optional additions
+- Add ability for quantum siblings to swap their bodies when they hug.
+- Allow more than 2 players to become quantum siblings.
+- Add a way to destroy quantum connection with penalty to both siblings.

--- a/src/design-proposals/subroles/subroles.md
+++ b/src/design-proposals/subroles/subroles.md
@@ -1,0 +1,58 @@
+# Subroles Design
+Subroles are additonal roles for players in Space Station 14. They are to the main roles in that they provide additional gameplay opportunities and player interactions. Yet, they are have big differences.
+
+Main difference between subrole. Main specificity of subroles - subroles are designed to provide additional gameplay environment and goals for players rather than determining the side of conflict between the antagonists and the crew. They also provide less roundflow changes for player. 
+
+Another big difference - player usually can have only one main role (nuclear operative, traitor, etc.) and multiple subroles. This also means that main bearers of subroles will be non-antagonists or crew related players.
+
+The purpose of this document is to describe how additional roles differ from main roles and which roles should be considered as such. In addition, document will also try to suggest changes to existing roles to make them subroles.
+
+This document is not a strict list of requirements but intends to serve as a foundation for what subroles should feel and play like. In some cases a particular subrole may deviate from the principles in this doc, and that’s fine as long as the design still works and provides quality gameplay.
+
+---
+
+# Design Pillars
+
+These are the core design pillars for subroles. The design of all subroles should follow these pillars as closely as possible.
+
+## Gameplay and not just name
+
+- Subroles should provide new gameplay opportuinities for players, not just name with description. It's not fun to have a title without any impact.
+
+## Keep allegiance
+
+- Subroles shouldn't change allegiance of players. Crew-sided player should still work on crew's side even if they get subroles that allows them playing a more antagonistic character than usual. 
+  
+## Shift with additions
+
+- Subroles should not globally change roundflow of player, but diversify this roundflow. Medical Doctor with subrole should still heal people in medical department with little changes in their gameplay due to subrole.
+
+## Changeability
+
+- Subroles should be able to change during round. When it not apply to all subroles, this most be feature of most subroles.
+
+## For everyone
+
+- Subroles should be accessible for antagonists, for crew, for silicons and even for animal players. Some roles should be blacklisted if you have some specific role (antagonist shouldn't get pacifism-related subroles.)
+  
+## Accessibility
+
+- Players with subrole should be provided with all information required to understand mechanics of their, along with their permissions and restrictions.
+
+---
+
+# Examples of subroles
+
+## Thief
+
+Thief is first role that comes on mind when we talk about subroles. Historically thief was never real antagonist - they were annoying, they had impact on round, but they were never evil enough to be accounted as antagonist. 
+
+Even in antagonist - station confrontation thief often take side of crew, helping (or at least not preventing) crew to fight antags even with pacifism.
+
+## Anomaly hosts
+
+Anomaly hosts always get new interactions with other players, along with getting new goal - not die from anomaly. Meat anomaly host can build their base in maints, covered in meat abomination (they not attack anomaly host), shadow anomaly host can cover station in darkness. Yet, ignoring this subrole from player or from station side can lead to bad end.
+
+## Subversed cyborg
+
+Cyborgs with changed laws still have their main goal - follow the laws. Yet, changed laws always lead to giggles or even interesting interactions with crew and silicons.


### PR DESCRIPTION
Fast design document about new roles type - subroles that work similar to current ingame roles, but have quite differences.

With them I added proposal of new subrole - Quantum siblings - two humanoids of same species that share same health and status effects!