### PR TITLE
Remove botany

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install mdbook & plugins
         uses: taiki-e/install-action@v2.18.6
         with:
-          tool: mdbook@0.5.3,mdbook-admonish@1.20.0,mdbook-alerts@0.8.0,mdbook-emojicodes@0.3.0
+          tool: mdbook@0.4.52,mdbook-admonish@1.20.0,mdbook-alerts@0.8.0,mdbook-emojicodes@0.3.0
       - name: Update SUMMARY.md with proposals
         run: python3 tools/auto-update-design-proposals.py
       - name: Setup Pages

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -32,7 +32,6 @@ Proposals
   - [Map Template](design/maps/template.md)
 
 - [Game Design Proposals]()
-  - [Hydroponics ](design-proposals/botany-changes.md)
   - ["Corporate Secrets"](design-proposals/corporate-secrets.md)
   - [Lasers and Armory Overhaul](design-proposals/lasers.md)
   - [Company Scrip](design-proposals/scrip.md)


### PR DESCRIPTION
Removes the botany document from the summary, because it's causing the build to fail and I'm diagnosing the workflow. Also, no one has touched it in a while apparently.