### PR TITLE
Syndicate uplink changes

### DIFF
--- a/src/design-proposals/syndicate-weaponry.md
+++ b/src/design-proposals/syndicate-weaponry.md
@@ -1,0 +1,81 @@
+# Syndicate: Spy vs Soldier
+
+| Designers   | Implemented | GitHub Links |
+|-------------|-------------|--------------|
+| Tea         | ❌ No        | PTBD         |
+| miiish      | ❌ No        | PTBD         |
+| mkanke-real | ❌ No        | PTBD         |
+
+## Summary
+
+This document proposes a multitude of changes to the syndicate uplink:
+- Establishes a clearer separation (although not mechanically enforced) between syndicate agents and nuclear operatives.
+- Quality/ direction pass on all syndicate uplink options, with weapons receiving the brunt of the changes.
+- Proposes new uplink options, in particular new "spy gadget" options to give traitors a more covert vibe and 
+    allow a greater variety of stealth options for nuclear operatives.
+- Provides a clear visual direction for the syndicate arsenal in the interim
+
+## Problems
+
+The current syndicate uplink lacks options with considerable difference in how they feel - both in visuals and gameplay.
+This issue is particularly prevalent with the gun options, with many of them just being "X weapon type but full auto".
+The current arsenal includes:
+a fully automatic pistol, SMG, shotgun and LMG. This document proposes that this is a design flaw, and limits
+the creativity at which players can operate and contributes to the feeling of "saminess" some antagonist rounds
+are subject to.
+
+Furthermore, the current arsenal also lacks options that allow the syndicate agent to truly feel like a covert
+agent. This document hopes to at least take a step further towards that goal by introducing a few more sci-fi
+gadgets, in addition to the [listening & camera bugs](https://github.com/funky-station/forky-station/pull/85).
+
+## Intent
+
+The first and foremost priority of the document is to do a quality/direction pass for what is currently already implemented.
+What this means is making existing options more in line with the document's overarching design principle of
+slower, more deliberate and deadlier combat.
+
+Secondarily, this document wishes to give the facets of the syndicate more individual personality. Gorlex & Interdyne
+being more focused on overt stuff, with Gorlex being more bullheaded and Interdyne more experimental. Conversely
+Cybersun would be conventionally covert stuff, with Donk Co. having unconventional/strange options. 
+Not all items will be beholden to a specific company, but many will with each company having some unique 
+design aspects.
+
+## Solution
+
+### Uplink quality/ direction pass
+
+Items not named are likely to remain the same in function for the time being. Damage is not being discussed and will
+likely be iterative instead. Prices are not discussed as the prices are still currently being solidified 
+separately of this document.
+
+#### Weaponry
+
+- Razor-lined bowler hat: needs to be activated to reveal the razors. Otherwise looks like a normal bowler hat
+- Energy Dagger: deprecated. The syndicate no longer uses energy blades, and making a physical one would be pointless
+    as the Cybersun pen already exists in addition to the hypopen and explosive pen. There's many covert pen options.
+- Viper: no longer fully automatic, but uses caseless ammunition. Good for magdumping someone and making a quick escape.
+- Cobra → Cobra Welrod: 6-8 magazine capacity. Good damage, poor accuracy and needs to be bolted after every shot.
+    the budget assassin's weapon, perfect for shooting someone in the back and finishing the job silently.
+- Throwing knives kit: buff melee damage and revert the projectile speed nerf from a few months ago.
+    Even a knife designed for throwing would hurt more than a fist...
+- Taipan chem-crossbow: shoots syringes instead of current phoron ammo. Instead, comes bundled with a proprietary 
+    Interdyne poison.
+- Fists of the North Star: needs to be reflavoured as something that isn't a 1:1 reference, likely Cybersun
+- Anaconda: it's an oversized gun. This shit is Gorlex central.
+- Energy sword → high-frequency machete: no longer pocket-sized when turned off, but remains a high slash damage
+    weapon even while it's turned off. Turning it on causes it to make chainsaw-like noises, allowing it to slice
+    through structures just like the energy sword.
+- Energy shield → reflective telescopic shield: same thing, just reflavoured.
+- Hristov → Anti-material railgun: reduce the slowdown, increase the structural damage. I expect it will
+    see more use due to security's new structure-oriented playstyle. Having a weapon like the hristov or china lake
+    will likely be imperative if you want to brute force through those.
+- Hushpup: make this pump-action. The movie version isn't pump-action, but the gun it is based off of - the Remington 870
+    with a suppresor - is.
+- C-20r Submachine gun: full auto replaced with 3-shot burst fire.
+- Bulldog: no longer fully automatic.
+- L6 Saw: remains the same, but due to other changes this weapon's special feature *is* the full auto and high mag capacity.
+- China-Lake: remains the same until we can see how it does outside of warops.
+
+#### Wearables
+
+- Chameleon nightvision goggles: the chameleon part needs to actually work for this to be implemented. 


### PR DESCRIPTION
This is part 3 of a 3 part document which seeks to provide overarching changes to the weapons of Funky Station, to bring the areas touched more in line with antagonist-optional design.

This part focuses on the syndicate, primarily a direction pass & giving the companies the syndicate is comprised of more identity.
